### PR TITLE
feat(metrics): add internal metrics for action duration and scan stats

### DIFF
--- a/switchbot_actions/signals.py
+++ b/switchbot_actions/signals.py
@@ -4,5 +4,11 @@ from blinker import signal
 switchbot_advertisement_received = signal("switchbot-advertisement-received")
 mqtt_message_received = signal("mqtt-message-received")
 
+# Internal monitoring notification
+scan_executed = signal("scan-executed")
+
 # Internal action request
 publish_mqtt_message_request = signal("publish-mqtt-message-request")
+
+# Internal action notification
+action_executed = signal("action-executed")


### PR DESCRIPTION
Added Prometheus metrics to track action execution time, BLE scan duration, and total received advertisements.