### PR TITLE
feat(actions): support list and raw string payloads for Webhook and MQTT

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -304,11 +304,13 @@ The `then` block specifies one or more actions to execute when the `if` conditio
 - **`webhook`**: Sends an HTTP request.
   - `url`: (string, required) The target URL.
   - `method`: (string, optional, default: `POST`) `POST` or `GET`.
-  - `payload`: (map or string, optional) For `POST`, this is the JSON body. For `GET`, these are the URL query parameters.
+  - `payload`: (map, list, or string, optional)
+    - **POST**: Maps and lists are sent as **JSON**. Strings are sent as **raw body content**.
+    - **GET**: Must be a map (key-value pairs) or query string.
   - `headers`: (map, optional) Custom HTTP headers.
 - **`mqtt_publish`**: Publishes a message to an MQTT topic.
   - `topic`: (string, required) The target topic.
-  - `payload`: (map or string, optional) The message payload. Maps are sent as JSON.
+  - `payload`: (map, list, or string, optional) The message payload. Maps and lists are sent as JSON.
   - `qos`: (integer, optional, default: `0`) Quality of Service (`0`, `1`, or `2`).
   - `retain`: (boolean, optional, default: `false`) The retain flag.
 - **`switchbot_command`**: Directly controls another SwitchBot device.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "switchbot-actions"
-version = "2.1.0"
+version = "2.2.0"
 authors = [
     {name = "Yoshio HANAWA", email = "y@hnw.jp"},
 ]

--- a/switchbot_actions/config.py
+++ b/switchbot_actions/config.py
@@ -147,7 +147,7 @@ class WebhookAction(BaseConfigModel):
     type: Literal["webhook"]
     url: str
     method: str = "POST"
-    payload: Union[str, Dict[str, Any]] = ""
+    payload: Union[Dict[str, Any], List[Any], str] = ""
     headers: Dict[str, Any] = Field(default_factory=dict)
 
     @field_validator("method")
@@ -157,11 +157,20 @@ class WebhookAction(BaseConfigModel):
             raise ValueError("method must be POST or GET")
         return upper_v
 
+    @model_validator(mode="after")
+    def validate_payload_for_method(self) -> "WebhookAction":
+        if self.method == "GET" and isinstance(self.payload, list):
+            raise ValueError(
+                "Payload cannot be a list when method is GET. "
+                "Use a dictionary (key-value pairs) for query parameters."
+            )
+        return self
+
 
 class MqttPublishAction(BaseConfigModel):
     type: Literal["mqtt_publish"]
     topic: str
-    payload: Union[str, Dict[str, Any]] = ""
+    payload: Union[str, Dict[str, Any], List[Any]] = ""
     qos: Literal[0, 1, 2] = 0
     retain: bool = False
 

--- a/switchbot_actions/mqtt.py
+++ b/switchbot_actions/mqtt.py
@@ -1,7 +1,7 @@
 import asyncio
 import json
 import logging
-from typing import Any, Dict, Optional, Union, cast
+from typing import Any, Dict, List, Optional, Union, cast
 
 import aiomqtt
 from blinker import signal
@@ -116,11 +116,11 @@ class MqttClient(BaseComponent[MqttSettings]):
     async def publish(
         self,
         topic: str,
-        payload: Union[str, Dict[str, Any]],
+        payload: Union[str, Dict[str, Any], List[Any]],
         qos: int = 0,
         retain: bool = False,
     ):
-        if isinstance(payload, dict):
+        if isinstance(payload, (dict, list)):
             payload = json.dumps(payload)
         try:
             await self.client.publish(topic, str(payload), qos=qos, retain=retain)


### PR DESCRIPTION
Enabled sending JSON arrays and raw body content (e.g., text/plain) in Webhook actions, and added support for list-type payloads in MQTT actions. Also updated configuration validation and documentation.